### PR TITLE
🔀 :: (#207) 상벌점 부여 알림 content 수정

### DIFF
--- a/point-domain/src/main/kotlin/com/xquare/v1servicepoint/point/api/impl/PointHistoryApiImpl.kt
+++ b/point-domain/src/main/kotlin/com/xquare/v1servicepoint/point/api/impl/PointHistoryApiImpl.kt
@@ -138,13 +138,14 @@ class PointHistoryApiImpl(
         }
     }
 
-    private fun convertPostPosition(reason: String): String {
+    private fun convertPostfix(reason: String): String {
         val lastSpell = reason.last()
-        return if ((lastSpell.code - 0xAC00) % 28 > 0 && (lastSpell.code - 0xAC00) % 28 != 8) {
-            reason + "으로"
+        val postfix = if ((lastSpell.code - 0xAC00) % 28 > 0 && (lastSpell.code - 0xAC00) % 28 != 8) {
+            "으로"
         } else {
-            reason + "로"
+            "로"
         }
+        return reason + postfix
     }
 
     override suspend fun queryUserPointHistoryExcel(): ExportUserPointStatusResponse {

--- a/point-domain/src/main/kotlin/com/xquare/v1servicepoint/point/api/impl/PointHistoryApiImpl.kt
+++ b/point-domain/src/main/kotlin/com/xquare/v1servicepoint/point/api/impl/PointHistoryApiImpl.kt
@@ -72,7 +72,7 @@ class PointHistoryApiImpl(
     }
 
     private suspend fun sendNotification(userId: UUID, isGoodPoint: Boolean, reason: String, point: Int) {
-        val notificationMessage = "${reason}으로 인해 ${point}점을 받았어요."
+        val notificationMessage = convertPostPosition(reason) + " 인해 ${point}점을 받았습니다."
         val topic = if (isGoodPoint) "ALL_GOOD_POINT" else "ALL_BAD_POINT"
         val threadId = "ALL_POINT"
 
@@ -136,6 +136,14 @@ class PointHistoryApiImpl(
             "BADPOINT" -> false
             else -> null
         }
+    }
+
+    private fun convertPostPosition(reason: String): String {
+        val lastSpell = reason.last()
+        val reason = if ((lastSpell.code - 0xAC00) % 28 > 0 && (lastSpell.code - 0xAC00) % 28  != 8) {
+            reason + "으로"
+        } else reason + "로"
+        return reason
     }
 
     override suspend fun queryUserPointHistoryExcel(): ExportUserPointStatusResponse {

--- a/point-domain/src/main/kotlin/com/xquare/v1servicepoint/point/api/impl/PointHistoryApiImpl.kt
+++ b/point-domain/src/main/kotlin/com/xquare/v1servicepoint/point/api/impl/PointHistoryApiImpl.kt
@@ -140,9 +140,11 @@ class PointHistoryApiImpl(
 
     private fun convertPostPosition(reason: String): String {
         val lastSpell = reason.last()
-        return  if ((lastSpell.code - 0xAC00) % 28 > 0 && (lastSpell.code - 0xAC00) % 28  != 8) {
+        return if ((lastSpell.code - 0xAC00) % 28 > 0 && (lastSpell.code - 0xAC00) % 28 != 8) {
             reason + "으로"
-        } else reason + "로"
+        } else {
+            reason + "로"
+        }
     }
 
     override suspend fun queryUserPointHistoryExcel(): ExportUserPointStatusResponse {

--- a/point-domain/src/main/kotlin/com/xquare/v1servicepoint/point/api/impl/PointHistoryApiImpl.kt
+++ b/point-domain/src/main/kotlin/com/xquare/v1servicepoint/point/api/impl/PointHistoryApiImpl.kt
@@ -72,7 +72,7 @@ class PointHistoryApiImpl(
     }
 
     private suspend fun sendNotification(userId: UUID, isGoodPoint: Boolean, reason: String, point: Int) {
-        val notificationMessage = convertPostPosition(reason) + " 인해 ${point}점을 받았습니다."
+        val notificationMessage = convertPostfix(reason) + " 인해 ${point}점을 받았습니다."
         val topic = if (isGoodPoint) "ALL_GOOD_POINT" else "ALL_BAD_POINT"
         val threadId = "ALL_POINT"
 
@@ -140,11 +140,8 @@ class PointHistoryApiImpl(
 
     private fun convertPostfix(reason: String): String {
         val lastSpell = reason.last()
-        val postfix = if ((lastSpell.code - 0xAC00) % 28 > 0 && (lastSpell.code - 0xAC00) % 28 != 8) {
-            "으로"
-        } else {
-            "로"
-        }
+        val isPostfix =((lastSpell.code - 0xAC00) % 28 > 0 && (lastSpell.code - 0xAC00) % 28 != 8)
+        val postfix = if(isPostfix) "으로" else "로"
         return reason + postfix
     }
 

--- a/point-domain/src/main/kotlin/com/xquare/v1servicepoint/point/api/impl/PointHistoryApiImpl.kt
+++ b/point-domain/src/main/kotlin/com/xquare/v1servicepoint/point/api/impl/PointHistoryApiImpl.kt
@@ -140,10 +140,9 @@ class PointHistoryApiImpl(
 
     private fun convertPostPosition(reason: String): String {
         val lastSpell = reason.last()
-        val reason = if ((lastSpell.code - 0xAC00) % 28 > 0 && (lastSpell.code - 0xAC00) % 28  != 8) {
+        return  if ((lastSpell.code - 0xAC00) % 28 > 0 && (lastSpell.code - 0xAC00) % 28  != 8) {
             reason + "으로"
         } else reason + "로"
-        return reason
     }
 
     override suspend fun queryUserPointHistoryExcel(): ExportUserPointStatusResponse {

--- a/point-domain/src/main/kotlin/com/xquare/v1servicepoint/point/api/impl/PointHistoryApiImpl.kt
+++ b/point-domain/src/main/kotlin/com/xquare/v1servicepoint/point/api/impl/PointHistoryApiImpl.kt
@@ -140,8 +140,8 @@ class PointHistoryApiImpl(
 
     private fun convertPostfix(reason: String): String {
         val lastSpell = reason.last()
-        val isPostfix =((lastSpell.code - 0xAC00) % 28 > 0 && (lastSpell.code - 0xAC00) % 28 != 8)
-        val postfix = if(isPostfix) "으로" else "로"
+        val isPostfix = ((lastSpell.code - 0xAC00) % 28 > 0 && (lastSpell.code - 0xAC00) % 28 != 8)
+        val postfix = if (isPostfix) "으로" else "로"
         return reason + postfix
     }
 


### PR DESCRIPTION
![다운로드 (5)](https://github.com/team-xquare/v1-point-service/assets/103026521/e24394c9-e1b1-4293-84a5-6234391a7425)

- 유니코드 값을 이용하며 마지막 글자의 받침을 유니코드로 변환
- 받침이 없거나 'ㄹ'일 경우 -> "로" / 받침이 있는 경우 -> "으로"인 것을 참고하여 사유 뒤에 조사 붙임
---
`1. 마지막 글자의 받침 유니코드 - 처음 시작하는 유니코드(0번째, 사진 참고)
2.  종성의 개수만큼 나머지 연산
3. 사진 참고하여 비교문 작성`

- 한글 처음 시작하는 유니코드 : 0xAC00
- 종성의 개수 28개
---
![image](https://github.com/team-xquare/v1-point-service/assets/103026521/0cf3ab3f-d8e8-42f7-ac99-08a2171d81d6)