### PR TITLE
🔀 :: 다벌점 교육 완료 API IndexOutOfBounds 예외 수정

### DIFF
--- a/point-domain/src/main/kotlin/com/xquare/v1servicepoint/point/api/impl/PointStatusApiImpl.kt
+++ b/point-domain/src/main/kotlin/com/xquare/v1servicepoint/point/api/impl/PointStatusApiImpl.kt
@@ -27,7 +27,7 @@ class PointStatusApiImpl(
 ) : PointStatusApi {
 
     companion object {
-        val PENALTY_LEVEL_LIST = listOf(15, 20, 25, 35, 45)
+        val PENALTY_LEVEL_LIST = listOf(15, 20, 25, 35, 45, 60)
     }
 
     override suspend fun saveUserPenaltyEducationComplete(userId: UUID) {


### PR DESCRIPTION
- 기존 List에 45점까지만 존재했기 때문에 그 점수를 넘어가는 경우에 대해 IndexOutOfBounds가 발생
  해결위해 3out의 점수인 60점 List에 추가